### PR TITLE
Add an extra flag for utoipa output

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -21,6 +21,6 @@ jobs:
           # Creates a comment on the PR with details if issues were found
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run unit tests
-        run: cargo test --workspace
+        run: cargo test --workspace --all-features
       - name: Build documentation
         run: cargo doc --workspace --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "serde_option"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -352,13 +352,14 @@ dependencies = [
 
 [[package]]
 name = "serde_option_macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
  "serde_with",
  "syn 2.0.72",
+ "utoipa",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["Encoding"]
 
 [package]
 name = "serde_option"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 exclude = [".github/"]
 
@@ -29,11 +29,11 @@ categories.workspace = true
 utoipa = ["serde_option_macros/utoipa"]
 
 [dependencies]
-serde_option_macros = { path = "./serde_option_macros", version = "0.1.0" }
+serde_option_macros = { path = "./serde_option_macros", version = "0.2.0" }
 
 [dev-dependencies]
 trybuild = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = "3.9.0"
-utoipa = { version = "4.2.3" }
+utoipa = "4.2.3"

--- a/serde_option_macros/Cargo.toml
+++ b/serde_option_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_option_macros"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 repository.workspace = true
@@ -24,3 +24,4 @@ proc-macro2 = "1"
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_with = "3.9.0"
+utoipa = "4.2.3"

--- a/serde_option_macros/src/lib.rs
+++ b/serde_option_macros/src/lib.rs
@@ -222,24 +222,20 @@ fn process_optional_field(
                     with = "serde_with::rust::unwrap_or_skip")]
             });
             #[cfg(feature = "utoipa")]
-            {
-                if utoipa_flag {
-                    field.attrs.push(parse_quote! {
-                        #[schema(nullable = false)]
-                    })
-                }
+            if utoipa_flag {
+                field.attrs.push(parse_quote! {
+                    #[schema(nullable = false)]
+                })
             }
         } else if nullable && !not_required {
             field.attrs.push(parse_quote! {
                 #[serde(with = "Option")]
             });
             #[cfg(feature = "utoipa")]
-            {
-                if utoipa_flag {
-                    field.attrs.push(parse_quote! {
-                        #[schema(required = true)]
-                    })
-                }
+            if utoipa_flag {
+                field.attrs.push(parse_quote! {
+                    #[schema(required = true)]
+                })
             }
         } else if nullable && not_required {
             field.attrs.push(parse_quote! {


### PR DESCRIPTION
# Description

<!-- Please explain the changes you've made here, and whether it fixes an issue -->

This is a breaking change, so a version bump. Macro invocations that want to derive `utoipa` schemas should now explicitly opt in using `#[serde_option(utoipa)]`. This fixes an issue where just enabling the `utoipa` feature would blanket opt-in to generating `#[schema]` attributes, even if `#[derive(ToSchema)]` is not present.

## Checklist

<!-- Mark points with [x] -->

* [x] This is a code change
    * [x] I have run and tested the code to verify that it works
    * [x] I have added tests to cover any code changes
    * [x] I have updated the documentation accordingly
* [ ] This is NOT a code change (e.g. documentation, readme, etc. )
